### PR TITLE
normcase paths

### DIFF
--- a/pipsi.py
+++ b/pipsi.py
@@ -2,7 +2,7 @@ import os
 import sys
 import shutil
 import glob
-from os.path import join, realpath, dirname, normpath
+from os.path import join, realpath, dirname, normpath, normcase
 from operator import methodcaller
 try:
     from urlparse import urlparse
@@ -57,7 +57,7 @@ def normalize_package(value):
 
 
 def normalize(path):
-    return normpath(realpath(path))
+    return normcase(normpath(realpath(path)))
 
 
 def real_readlink(filename):
@@ -100,7 +100,7 @@ def publish_script(src, dst):
 
 
 def find_scripts(virtualenv, package):
-    prefix = join(normalize(virtualenv), BIN_DIR, '')
+    prefix = normalize(join(virtualenv, BIN_DIR, ''))
 
     files = statusoutput([
         join(prefix, 'python'), '-c', FIND_SCRIPTS_SCRIPT,

--- a/testing/test_repo.py
+++ b/testing/test_repo.py
@@ -6,12 +6,12 @@ from pipsi import Repo, find_scripts
 
 @pytest.fixture
 def bin(tmpdir):
-    return tmpdir.ensure('bin', dir=1)
+    return tmpdir.ensure('MixedCase', 'bin', dir=1)
 
 
 @pytest.fixture
 def home(tmpdir):
-    return tmpdir.ensure('venvs', dir=1)
+    return tmpdir.ensure('MixedCase', 'venvs', dir=1)
 
 
 @pytest.fixture
@@ -22,9 +22,9 @@ def repo(home, bin):
 def test_simple_install(repo, home, bin):
     assert not home.listdir()
     assert not bin.listdir()
-    repo.install('.')
-    assert home.join('pipsi').check()
-    assert bin.listdir('pipsi*')
+    repo.install('grin')
+    assert home.join('grin').check()
+    assert bin.listdir('grin*')
 
 
 def test_find_scripts():


### PR DESCRIPTION
This is the minimal change I had to do to let it find command scripts. Without normcase, the prefix match in `find_scripts` fails.
